### PR TITLE
Fix incorrect endISO for all-day events

### DIFF
--- a/scripts/event.jxa
+++ b/scripts/event.jxa
@@ -247,7 +247,7 @@
         start: allDay ? formatDateOnly(startDate) : formatLocalDate(startDate),
         end: allDay ? formatDateOnly(displayEndDate) : formatLocalDate(displayEndDate),
         startISO: formatISO(startDate),
-        endISO: formatISO(endDate),
+        endISO: formatISO(displayEndDate),
         isRecurring: isRecurring
       }
     });

--- a/scripts/events.jxa
+++ b/scripts/events.jxa
@@ -276,7 +276,7 @@
         start: allDay ? formatDateOnly(startDate) : formatLocalDate(startDate),
         end: allDay ? formatDateOnly(displayEndDate) : formatLocalDate(displayEndDate),
         startISO: formatISO(startDate),
-        endISO: formatISO(endDate),
+        endISO: formatISO(displayEndDate),
         isRecurring: isRecurring
       });
     } catch (e) {

--- a/scripts/freebusy.jxa
+++ b/scripts/freebusy.jxa
@@ -226,6 +226,12 @@
       try {
         var startDate = unwrap(event.startDate);
         var endDate = unwrap(event.endDate);
+        var allDay = !!unwrap(event.allDay);
+        var displayEndDate = endDate;
+        if (allDay) {
+          displayEndDate = new Date(endDate.getTime());
+          displayEndDate.setDate(displayEndDate.getDate() - 1);
+        }
 
         // EventKit predicate already returns overlapping events, no need to filter further
 
@@ -258,9 +264,9 @@
           calendarId: calId,
           summary: summary,
           start: formatLocalDate(startDate),
-          end: formatLocalDate(endDate),
+          end: formatLocalDate(displayEndDate),
           startISO: formatISO(startDate),
-          endISO: formatISO(endDate)
+          endISO: formatISO(displayEndDate)
         });
       } catch (e) {
         continue;


### PR DESCRIPTION
## Summary

Fixes a bug where all-day events return inconsistent ISO dates - the `endISO` field did not match the adjusted end date shown in the `end` field, making all-day events appear to span ~48 hours instead of 24.

## Root Cause

EventKit stores all-day events with time components. The code already adjusted `displayEndDate` (subtracting 1 day) for proper display in the `end` field, but the `endISO` field was using the raw `endDate` instead of `displayEndDate`.

## Example

Before this fix, a single-day all-day event on 2026-01-24 would show:
```json
{
  "start": "2026-01-24",
  "end": "2026-01-24",
  "startISO": "2026-01-23T23:00:00.000Z",
  "endISO": "2026-01-25T22:59:59.000Z"  // Wrong - spans ~48 hours
}
```

After this fix:
```json
{
  "start": "2026-01-24",
  "end": "2026-01-24",
  "startISO": "2026-01-23T23:00:00.000Z",
  "endISO": "2026-01-24T22:59:59.000Z"  // Correct - spans ~24 hours
}
```

## Changes

- **event.jxa**: Changed `endISO` to use `displayEndDate` instead of `endDate`
- **events.jxa**: Changed `endISO` to use `displayEndDate` instead of `endDate`
- **freebusy.jxa**: Added all-day event handling (was missing entirely) and updated both `end` and `endISO` to use `displayEndDate`

## Testing

Tested with the reported event:
```bash
accli event 9AA58CF3-5C63-4D04-BF25-0F6116CF7389:BEDEBD2D-6C30-48F8-BA3E-0679DEAEFFEF --json
```

The ISO dates are now consistent with the display dates.